### PR TITLE
Move messages include to the top

### DIFF
--- a/template.php
+++ b/template.php
@@ -13,6 +13,9 @@ if(isset($dir)) {
 	$tmpl_dir = dirname(__FILE__);
 }
 
+
+include "messages.php";
+
 // hide_index is for special case modules that may not need a display to students
 $templ["hide_index"] = "yes";
 $templ["index_loc"] = "{$tmpl_dir}/index.php";
@@ -36,5 +39,4 @@ switch ($lang1) {
 	// could add new language translations here as extra cases
 }
 
-include "messages.php";
 ?>


### PR DESCRIPTION
To give preference to "title" and "description" defined by template.php in case someone uses those names in messages.php and also to make it clearer that messages.php is being included for some future case where the number of translated templ is large